### PR TITLE
Remove ECR and docker

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -7,40 +7,14 @@ on:
 permissions:
   contents: read
 
-env:
-  MAJOR_VERSION: 0
-  MINOR_VERSION: 0
-  ECR_REGION: us-east-1
-  ECR_ALIAS: t6r8m9s8
-
 jobs:
-  get-version:
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - name: Set version
-        id: version
-        run: echo version=$MAJOR_VERSION.$MINOR_VERSION.${{ github.run_number }} >> $GITHUB_OUTPUT
   build-server:
     defaults:
       run:
         working-directory: ./VisaChecker.Server
     runs-on: ubuntu-latest
-    needs: [get-version]
     steps:
       - uses: actions/checkout@v2
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.ECR_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registry-type: public
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
@@ -51,33 +25,13 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build --no-daemon
-      - name: Build, tag, and push the image to Amazon ECR
-        id: build-image
-        env:
-          TAG: ${{ needs.get-version.outputs.version }}
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker build -t $REGISTRY/$ECR_ALIAS/visachecker-server:$TAG .
-          docker push $REGISTRY/$ECR_ALIAS/visachecker-server:$TAG
   build-ui:
     defaults:
       run:
         working-directory: ./VisaChecker.UI
     runs-on: ubuntu-latest
-    needs: [get-version]
     steps:
       - uses: actions/checkout@v2
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.ECR_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.ECR_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.ECR_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registry-type: public
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
@@ -87,11 +41,3 @@ jobs:
       - name: Install project dependencies
         run: npm ci
       - run: npm run build
-      - name: Build, tag, and push the image to Amazon ECR
-        id: build-image
-        env:
-          TAG: ${{ needs.get-version.outputs.version }}
-          REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-        run: |
-          docker build -t $REGISTRY/$ECR_ALIAS/visachecker-ui:$TAG .
-          docker push $REGISTRY/$ECR_ALIAS/visachecker-ui:$TAG


### PR DESCRIPTION
Because no providers have free tier managed kubernetes, we'll go with the monolith app for now